### PR TITLE
Fix .NET installation and VM password setup

### DIFF
--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -42,7 +42,11 @@ if [[ -n "$languages" ]]; then
       mise use --global java@latest
       ;;
     .NET)
-      sudo apt-get install -y dotnet-sdk-9.0
+      # Install .NET 9.0 using Microsoft's official installer
+      curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 9.0
+      # Add to PATH for current session and future sessions
+      echo 'export PATH="$HOME/.dotnet:$PATH"' >> ~/.bashrc
+      export PATH="$HOME/.dotnet:$PATH"
       ;;
     esac
   done

--- a/test/test-omakub.sh
+++ b/test/test-omakub.sh
@@ -6,6 +6,9 @@ REPO_RAW=https://raw.githubusercontent.com/Aaronontheweb/ardbegian/master/boot.s
 VM_NAME=omakub-test
 PASSWD=omakub     # password for "ubuntu" (RDP)
 
+# Generate hashed password for cloud-init
+PASSWD_HASH=$(openssl passwd -6 "$PASSWD")
+
 while [[ $# -gt 0 ]]; do
   case $1 in
     --vm)     VM_NAME="$2"; shift 2 ;;
@@ -27,11 +30,11 @@ multipass launch 24.04 \
 ssh_pwauth: true
 
 users:
-  - default
-chpasswd:
-  list: |
-    ubuntu:${PASSWD}      # <-- expands to the value you pass on the CLI
-  expire: false           # keep the password valid
+  - name: ubuntu
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    groups: [adm, cdrom, dip, plugdev, lxd, sudo]
+    hashed_passwd: ${PASSWD_HASH}
 
 bootcmd:
   # point resolved at Cloudflare + Google (edit to taste)


### PR DESCRIPTION
- Fix .NET 9.0 installation by using Microsoft's official installer script instead of trying to install non-existent dotnet-sdk-9.0 from apt
- Fix VM password setup in test-omakub.sh by using proper cloud-init hashed password configuration instead of plain text chpasswd
- Remove hacky fallback password setting methods
