### PR TITLE
Fix Caps Lock behavior and add workspace span all displays setting

### DIFF
--- a/install/desktop/set-gnome-hotkeys.sh
+++ b/install/desktop/set-gnome-hotkeys.sh
@@ -17,6 +17,9 @@ gsettings set org.gnome.desktop.wm.keybindings toggle-fullscreen "['<Shift>F11']
 gsettings set org.gnome.mutter dynamic-workspaces false
 gsettings set org.gnome.desktop.wm.preferences num-workspaces 6
 
+# Make workspaces span all displays (not just primary)
+gsettings set org.gnome.mutter workspaces-only-on-primary false
+
 # Use alt for pinned apps
 gsettings set org.gnome.shell.keybindings switch-to-application-1 "['<Alt>1']"
 gsettings set org.gnome.shell.keybindings switch-to-application-2 "['<Alt>2']"


### PR DESCRIPTION
- Remove Caps Lock remapping to Ctrl from set-gnome-hotkeys.sh
- Remove Caps Lock remapping to Compose from set-xcompose.sh
- Add workspace span all displays setting to set-gnome-hotkeys.sh
- Ensures Caps Lock works as default Caps Lock key
- Configures workspaces to switch across all monitors
