### PR TITLE
Fix JetBrains Toolbox installation and menu integration

### DIFF
--- a/bin/omakub-sub/install-dev-editor.sh
+++ b/bin/omakub-sub/install-dev-editor.sh
@@ -14,8 +14,31 @@ if [[ "$CHOICE" == "<< Back"* ]] || [[ -z "$CHOICE" ]]; then
   # Don't install anything
   echo ""
 else
-  INSTALLER=$(echo "$CHOICE" | awk -F ' {2,}' '{print $1}' | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g')
-  INSTALLER_FILE="$OMAKUB_PATH/install/desktop/optional/app-$INSTALLER.sh"
+  # Extract the application name and map to the correct installer file
+  case "$CHOICE" in
+    "Cursor"*)
+      INSTALLER_FILE="$OMAKUB_PATH/install/desktop/optional/app-cursor.sh"
+      ;;
+    "Doom Emacs"*)
+      INSTALLER_FILE="$OMAKUB_PATH/install/desktop/optional/app-doom-emacs.sh"
+      ;;
+    "JetBrains Toolbox"*)
+      INSTALLER_FILE="$OMAKUB_PATH/install/desktop/optional/app-jetbrains-toolbox.sh"
+      ;;
+    "RubyMine"*)
+      INSTALLER_FILE="$OMAKUB_PATH/install/desktop/optional/app-rubymine.sh"
+      ;;
+    "Windsurf"*)
+      INSTALLER_FILE="$OMAKUB_PATH/install/desktop/optional/app-windsurf.sh"
+      ;;
+    "Zed"*)
+      INSTALLER_FILE="$OMAKUB_PATH/install/desktop/optional/app-zed.sh"
+      ;;
+    *)
+      echo "Unknown choice: $CHOICE"
+      exit 1
+      ;;
+  esac
 
   source $INSTALLER_FILE && gum spin --spinner globe --title "Install completed!" -- sleep 3
 fi

--- a/install/desktop/optional/app-jetbrains-toolbox.sh
+++ b/install/desktop/optional/app-jetbrains-toolbox.sh
@@ -1,23 +1,48 @@
 #!/bin/bash
 
-# Download and install JetBrains Toolbox
+# Install JetBrains Toolbox following official recommendations
+set -e
+
+# Check if already installed
+if [ -d ~/.local/share/JetBrains/Toolbox ]; then
+  echo "JetBrains Toolbox is already installed!"
+  echo "You can run 'jetbrains-toolbox' to launch it."
+  exit 0
+fi
+
+echo "Installing JetBrains Toolbox..."
+
+# Create necessary directories
+mkdir -p ~/.local/share/JetBrains/Toolbox/bin
+mkdir -p ~/.local/bin
+
+# Download the latest JetBrains Toolbox AppImage
 cd /tmp
+wget --show-progress -qO jetbrains-toolbox.tar.gz "https://data.services.jetbrains.com/products/download?platform=linux&code=TBA"
 
-# Download the latest JetBrains Toolbox App
-wget -O jetbrains-toolbox.tar.gz "https://download.jetbrains.com/toolbox/jetbrains-toolbox-1.28.1.15219.tar.gz"
+# Extract the AppImage
+TOOLBOX_TEMP_DIR=$(mktemp -d)
+tar -C "$TOOLBOX_TEMP_DIR" -xf jetbrains-toolbox.tar.gz
+rm jetbrains-toolbox.tar.gz
 
-# Extract the archive
-tar -xzf jetbrains-toolbox.tar.gz
+# Move the binary to the proper location
+mv "$TOOLBOX_TEMP_DIR"/*/jetbrains-toolbox ~/.local/share/JetBrains/Toolbox/bin/jetbrains-toolbox
+chmod +x ~/.local/share/JetBrains/Toolbox/bin/jetbrains-toolbox
 
-# Move to /opt for system-wide installation
-sudo mv jetbrains-toolbox-* /opt/jetbrains-toolbox
-
-# Make it executable
-sudo chmod +x /opt/jetbrains-toolbox/jetbrains-toolbox
+# Create symlink if ~/.local/bin is in PATH
+if [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
+  ln -sf ~/.local/share/JetBrains/Toolbox/bin/jetbrains-toolbox ~/.local/bin/jetbrains-toolbox
+fi
 
 # Clean up
-rm -f jetbrains-toolbox.tar.gz
-cd -
+rm -rf "$TOOLBOX_TEMP_DIR"
 
 echo "JetBrains Toolbox installed successfully!"
-echo "You can now install JetBrains Rider and other IDEs through the Toolbox." 
+echo "Starting JetBrains Toolbox for initial setup..."
+
+# Run toolbox to complete setup (creates desktop entry, etc.)
+~/.local/share/JetBrains/Toolbox/bin/jetbrains-toolbox &
+
+echo "JetBrains Toolbox is now running in the background."
+echo "You can now install JetBrains IDEs (Rider, IntelliJ, etc.) through the Toolbox."
+echo "The Toolbox will appear in your application menu and system tray." 

--- a/uninstall/app-jetbrains-toolbox.sh
+++ b/uninstall/app-jetbrains-toolbox.sh
@@ -1,10 +1,22 @@
 #!/bin/bash
 
 # Remove JetBrains Toolbox installation
-sudo rm -rf /opt/jetbrains-toolbox
+echo "Removing JetBrains Toolbox..."
 
-# Remove user data (optional - uncomment if you want to remove all data)
-# rm -rf ~/.local/share/JetBrains
-# rm -rf ~/.config/JetBrains
+# Remove the main installation directory
+rm -rf ~/.local/share/JetBrains/Toolbox
 
-echo "JetBrains Toolbox uninstalled successfully!" 
+# Remove symlink if it exists
+rm -f ~/.local/bin/jetbrains-toolbox
+
+# Remove desktop entry if it exists
+rm -f ~/.local/share/applications/jetbrains-toolbox.desktop
+
+# Remove autostart entry if it exists
+rm -f ~/.config/autostart/jetbrains-toolbox.desktop
+
+echo "JetBrains Toolbox uninstalled successfully!"
+echo "Note: Individual IDE installations and user data are preserved."
+echo "To remove all JetBrains data, run:"
+echo "  rm -rf ~/.local/share/JetBrains"
+echo "  rm -rf ~/.config/JetBrains" 


### PR DESCRIPTION
This commit resolves the issue where selecting 'JetBrains Toolbox' from the Omakub menu would fail silently due to incorrect file name resolution and outdated installation approach.

## Changes Made:

### 1. Fixed Menu Integration (bin/omakub-sub/install-dev-editor.sh)
- **Problem**: Menu parsing logic was extracting only the first word 'JetBrains' instead of the full 'JetBrains Toolbox', causing it to look for non-existent 'app-jetbrains.sh' instead of 'app-jetbrains-toolbox.sh'
- **Solution**: Replaced fragile regex parsing with explicit case statement that maps each menu choice directly to its corresponding installer file
- **Impact**: All editor installations now work reliably regardless of naming

### 2. Updated Installation Script (install/desktop/optional/app-jetbrains-toolbox.sh)
- **Problem**: Script used outdated tar.gz approach with hardcoded version, installed to /opt requiring sudo, didn't follow JetBrains recommendations
- **Solution**: Completely rewrote to follow official JetBrains installation pattern:
  - Downloads latest version automatically via JetBrains API
  - Installs to ~/.local/share/JetBrains/Toolbox/bin (official location)
  - Creates symlink in ~/.local/bin for PATH access
  - Runs toolbox once for automatic setup (desktop entries, system tray)
  - Added duplicate installation detection and proper error handling
  - No sudo required - follows user-space installation pattern

### 3. Updated Uninstall Script (uninstall/app-jetbrains-toolbox.sh)
- **Problem**: Uninstall script targeted old /opt installation location
- **Solution**: Updated to properly clean up new installation:
  - Removes ~/.local/share/JetBrains/Toolbox directory
  - Removes ~/.local/bin/jetbrains-toolbox symlink
  - Removes desktop and autostart entries
  - Provides clear instructions for complete data removal

## Technical Details:

- Installation now uses JetBrains' official AppImage distribution
- Follows XDG Base Directory Specification for Linux installations
- Toolbox automatically handles desktop integration and PATH setup
- No manual desktop launcher creation needed (handled by Toolbox itself)
- Installation is fully reversible and doesn't require elevated privileges

## Testing:

- Verified menu selection now correctly identifies installer file
- Confirmed installation follows official JetBrains recommendations
- Tested that Toolbox appears in application menu and system tray after install
- Verified uninstall properly removes all created files and symlinks

Fixes the reported issue where JetBrains Toolbox installation would fail silently when selected from the Omakub development editor menu.
