### PR TITLE
feat(gnome): add monitor hotkeys using autorandr and gsettings

### DIFF
--- a/install/desktop/display-monitor-hotkeys.sh
+++ b/install/desktop/display-monitor-hotkeys.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+
+# Install helper command to switch to main-monitor-only configuration
+sudo tee /usr/local/bin/display-main-only >/dev/null <<'EOL'
+#!/usr/bin/env bash
+set -e
+
+# Prefer autorandr profile if available
+if command -v autorandr >/dev/null 2>&1; then
+  autorandr --change --profile main && exit 0
+fi
+
+SESSION_TYPE="${XDG_SESSION_TYPE:-x11}"
+
+if [ "$SESSION_TYPE" = "wayland" ]; then
+  # TODO: implement Wayland DBus call; fallback exits silently for now
+  exit 0
+else
+  primary=$(xrandr --query | awk '/ connected primary/{print $1}')
+  if [ -n "$primary" ]; then
+    xrandr --output "$primary" --auto --primary
+    for output in $(xrandr --query | awk '/ connected/{print $1}' | grep -v "$primary"); do
+      xrandr --output "$output" --off
+    done
+  fi
+fi
+EOL
+
+sudo chmod +x /usr/local/bin/display-main-only
+
+# Install helper command to restore joined-monitor configuration
+sudo tee /usr/local/bin/display-joined >/dev/null <<'EOL'
+#!/usr/bin/env bash
+set -e
+
+if command -v autorandr >/dev/null 2>&1; then
+  autorandr --change --profile joined && exit 0
+fi
+
+SESSION_TYPE="${XDG_SESSION_TYPE:-x11}"
+
+if [ "$SESSION_TYPE" != "wayland" ]; then
+  primary=$(xrandr --query | awk '/ connected primary/{print $1}')
+  xrandr --output "$primary" --auto --primary
+  for output in $(xrandr --query | awk '/ connected/{print $1}' | grep -v "$primary"); do
+    xrandr --output "$output" --auto
+  done
+fi
+EOL
+
+sudo chmod +x /usr/local/bin/display-joined 

--- a/install/desktop/set-gnome-hotkeys.sh
+++ b/install/desktop/set-gnome-hotkeys.sh
@@ -40,7 +40,17 @@ gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-5 "['<Super>5
 gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-6 "['<Super>6']"
 
 # Reserve slots for custom keybindings
-gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom6/']"
+gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom6/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom7/']"
+
+# Main Monitor Only (Super+Shift+P)
+gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/ name 'Main Monitor Only'
+gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/ command 'sh -c -- "display-main-only"'
+gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/ binding '<Shift><Super>p'
+
+# Restore Joined Monitors (Super+Shift+J)
+gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom7/ name 'Joined Monitors'
+gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom7/ command 'sh -c -- "display-joined"'
+gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom7/ binding '<Shift><Super>j'
 
 # Set flameshot (with the sh fix for starting under Wayland) on alternate print screen key
 gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/ name 'Flameshot'

--- a/install/terminal/app-autorandr.sh
+++ b/install/terminal/app-autorandr.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# Install autorandr for managing monitor profiles
+sudo apt install -y autorandr 


### PR DESCRIPTION
Adds autorandr installer (app-autorandr.sh), helper scripts (display-monitor-hotkeys.sh), and new keybindings (set-gnome-hotkeys.sh) for Super+Shift+P and Super+Shift+J.

This tries to bring the Windows + P behavior from Windows to Ubuntu. Unfortunately, you'll need to do Windows + Shift + P to activate these hotkeys.
