### PR TITLE
Resolve Missing Slack and Discord installs

### DIFF
--- a/bin/omakub-sub/install.sh
+++ b/bin/omakub-sub/install.sh
@@ -5,6 +5,7 @@ CHOICES=(
   "1password         Manage your passwords securely across devices"
   "Audacity          Record and edit audio"
   "ASDControl        Set brightness on Apple Studio and XDR displays"
+  "Discord           Chat for Communities and Friends"
   "Dropbox           Sync files across computers with ease"
   "Gimp              Image manipulation tool ala Photoshop"
   "Geekbench         CPU benchmaking tool"
@@ -13,6 +14,7 @@ CHOICES=(
   "OBS Studio        Record screencasts with inputs from both display + webcam"
   "Ollama            Run LLMs, like Meta's Llama3, locally"
   "Retroarch         Play retro games"
+  "Slack             Team communication and collaboration platform"
   "Spotify           Stream music from the world's most popular service"
   "Steam             Play games from Valve's store"
   "Tailscale         Mesh VPN based on WireGuard and with Magic DNS"
@@ -46,6 +48,8 @@ else
   "ollama") INSTALLER_FILE="$OMAKUB_PATH/install/terminal/optional/app-ollama.sh" ;;
   "tailscale") INSTALLER_FILE="$OMAKUB_PATH/install/terminal/optional/app-tailscale.sh" ;;
   "geekbench") INSTALLER_FILE="$OMAKUB_PATH/install/terminal/optional/app-geekbench.sh" ;;
+  "discord") INSTALLER_FILE="$OMAKUB_PATH/install/desktop/app-discord.sh" ;;
+  "slack") INSTALLER_FILE="$OMAKUB_PATH/install/desktop/app-slack.sh" ;;
   *) INSTALLER_FILE="$OMAKUB_PATH/install/desktop/optional/app-$INSTALLER.sh" ;;
   esac
 

--- a/install/desktop/app-discord.sh
+++ b/install/desktop/app-discord.sh
@@ -1,4 +1,3 @@
-wget -qO- https://discord.com/api/downloads/distro/app/stream/x86_64 -O /tmp/discord.deb
-sudo dpkg -i /tmp/discord.deb
-sudo apt-get install -f -y
-rm /tmp/discord.deb 
+#!/bin/bash
+# Install Discord via snap (more reliable than direct deb download)
+sudo snap install discord 

--- a/install/desktop/app-slack.sh
+++ b/install/desktop/app-slack.sh
@@ -1,4 +1,3 @@
-wget -qO- https://downloads.slack-edge.com/releases/linux/64/deb/slack-desktop-4.0.2-amd64.deb -O /tmp/slack-desktop.deb
-sudo dpkg -i /tmp/slack-desktop.deb
-sudo apt-get install -f -y
-rm /tmp/slack-desktop.deb 
+#!/bin/bash
+# Install Slack via snap (official recommended method for Linux)
+sudo snap install slack --classic 

--- a/install/terminal/required/app-essential-utils.sh
+++ b/install/terminal/required/app-essential-utils.sh
@@ -31,4 +31,9 @@ if ! command -v git &> /dev/null; then
     sudo apt install -y git
 fi
 
+# Install snapd (used for snap package installations)
+if ! command -v snap &> /dev/null; then
+    sudo apt install -y snapd
+fi
+
 echo "Essential utilities installed" 

--- a/uninstall/app-discord.sh
+++ b/uninstall/app-discord.sh
@@ -1,2 +1,2 @@
-sudo apt-get remove --purge -y discord
-rm -f ~/.local/share/applications/Discord.desktop 
+#!/bin/bash
+sudo snap remove discord 

--- a/uninstall/app-slack.sh
+++ b/uninstall/app-slack.sh
@@ -1,2 +1,2 @@
-sudo apt-get remove --purge -y slack-desktop
-rm -f ~/.local/share/applications/Slack.desktop 
+#!/bin/bash
+sudo snap remove slack 


### PR DESCRIPTION
Fix Slack and Discord installation by switching to Snap packages and updating Omakub menu choices.

close #32

The previous `.deb` download URLs for Slack and Discord were outdated and broken (403 Forbidden for Slack, 404 Not Found for Discord). Switching to Snap provides a more reliable, officially supported installation method, aligns with Ubuntu's recommended approach, and ensures `snapd` is installed. This PR also adds Slack and Discord to the Omakub menu for easier post-setup installation.