### PR TITLE
Alacritty: ensure that windows keybindings get copied over

### DIFF
--- a/install/desktop/app-alacritty.sh
+++ b/install/desktop/app-alacritty.sh
@@ -3,6 +3,7 @@ sudo apt install -y alacritty
 mkdir -p ~/.config/alacritty
 cp ~/.local/share/omakub/configs/alacritty.toml ~/.config/alacritty/alacritty.toml
 cp ~/.local/share/omakub/configs/alacritty/shared.toml ~/.config/alacritty/shared.toml
+cp ~/.local/share/omakub/configs/alacritty/windows-keybindings.toml ~/.config/alacritty/windows-keybindings.toml
 cp ~/.local/share/omakub/configs/alacritty/pane.toml ~/.config/alacritty/pane.toml
 cp ~/.local/share/omakub/configs/alacritty/btop.toml ~/.config/alacritty/btop.toml
 cp ~/.local/share/omakub/themes/tokyo-night/alacritty.toml ~/.config/alacritty/theme.toml


### PR DESCRIPTION
This is what caused Alacritty to brick on some clean installs